### PR TITLE
feat: initial plugin implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Neovim
+*.swp
+*.swo
+*~
+.netrwhist
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Project
+/tags
+/.luarc.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,73 @@
 # ccmanager.nvim
-Neovim plugin for CCManager - Claude Code session manager
+
+Neovim plugin for [CCManager](https://github.com/kbwo/ccmanager) - Claude Code Session Manager integration using toggleterm.nvim.
+
+CCManager is a TUI application for managing multiple Claude Code sessions across Git worktrees. This plugin allows you to run CCManager directly within Neovim.
+
+[CCManager](https://github.com/kbwo/ccmanager)は、複数のClaude Codeセッションを Git worktree間で管理するためのTUIアプリケーションです。このプラグインを使用することで、NeovimからCCManagerを直接起動できます。
+
+## Requirements
+
+- Neovim >= 0.11.0
+- [toggleterm.nvim](https://github.com/akinsho/toggleterm.nvim)
+- Node.js (for running `npx ccmanager`)
+
+## Installation
+
+### Using [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+```lua
+{
+  "ishiooon/ccmanager.nvim",
+  dependencies = {
+    "akinsho/toggleterm.nvim",
+    version = "*",
+    config = true
+  },
+  config = function()
+    require("ccmanager").setup({
+      -- your configuration
+    })
+  end,
+}
+```
+
+## Configuration
+
+Default configuration:
+
+```lua
+require("ccmanager").setup({
+  keymap = "<leader>cm",           -- Keymap to toggle CCManager
+  window = {
+    size = 0.3,                    -- Window size (0-1 for percentage)
+    position = "right",            -- Window position: "right", "left", "bottom", "top"
+  },
+  command = "npx ccmanager",       -- Command to run CCManager
+})
+```
+
+## Usage / 使い方
+
+Press `<leader>cm` (default) to toggle the CCManager terminal window.
+
+`<leader>cm` (デフォルト) を押すことで、CCManagerのターミナルウィンドウを開閉できます。
+
+### Key mappings in terminal mode / ターミナルモードでのキーマッピング
+
+- `<Esc>` - Exit terminal mode to normal mode / ターミナルモードからノーマルモードへ
+- `<C-w>` - Window navigation from terminal mode / ターミナルモードからのウィンドウ操作
+
+## Credits
+
+- [kbwo/ccmanager](https://github.com/kbwo/ccmanager) - The amazing CCManager TUI application
+- [akinsho/toggleterm.nvim](https://github.com/akinsho/toggleterm.nvim) - Terminal management plugin for Neovim
+- [folke/lazy.nvim](https://github.com/folke/lazy.nvim) - Modern plugin manager for Neovim
+
+## Author
+
+ishiooon
+
+## License
+
+MIT

--- a/doc/ccmanager.txt
+++ b/doc/ccmanager.txt
@@ -1,0 +1,68 @@
+*ccmanager.txt*  Neovim plugin for CCManager
+
+==============================================================================
+CONTENTS                                                    *ccmanager-contents*
+
+1. Introduction ............................................. |ccmanager-intro|
+2. Setup .................................................... |ccmanager-setup|
+3. Configuration ........................................ |ccmanager-config|
+4. Commands ............................................. |ccmanager-commands|
+5. Mappings ............................................. |ccmanager-mappings|
+
+==============================================================================
+INTRODUCTION                                                   *ccmanager-intro*
+
+CCManager.nvim is a Neovim plugin that integrates CCManager (Claude Code Session
+Manager) into your editor using toggleterm.nvim. CCManager is a TUI application
+for managing multiple Claude Code sessions across Git worktrees. This plugin
+allows you to easily access CCManager from within Neovim.
+
+==============================================================================
+SETUP                                                          *ccmanager-setup*
+
+To use CCManager.nvim, you need to have toggleterm.nvim installed.
+
+Using lazy.nvim: >lua
+  {
+    "your-username/ccmanager.nvim",
+    dependencies = { "akinsho/toggleterm.nvim" },
+    config = function()
+      require("ccmanager").setup()
+    end,
+  }
+<
+
+==============================================================================
+CONFIGURATION                                                 *ccmanager-config*
+
+Call the setup function with your configuration: >lua
+  require("ccmanager").setup({
+    keymap = "<leader>cm",           -- Default keymap to toggle CCManager
+    window = {
+      size = 0.3,                    -- Window size (0-1 for percentage)
+      position = "right",            -- Window position: "right", "left", "bottom", "top"
+    },
+    command = "npx ccmanager",       -- Command to run CCManager
+  })
+<
+
+==============================================================================
+COMMANDS                                                    *ccmanager-commands*
+
+Currently, CCManager.nvim does not provide any commands. Use the keymap to
+toggle the CCManager terminal.
+
+==============================================================================
+MAPPINGS                                                    *ccmanager-mappings*
+
+*<leader>cm*
+    Toggle CCManager terminal window (default mapping)
+
+In terminal mode:
+*<Esc>*
+    Exit terminal mode to normal mode
+*<C-w>*
+    Window navigation from terminal mode
+
+==============================================================================
+vim:tw=78:ts=8:ft=help:norl:

--- a/lua/ccmanager.lua
+++ b/lua/ccmanager.lua
@@ -1,0 +1,1 @@
+return require("ccmanager")

--- a/lua/ccmanager/init.lua
+++ b/lua/ccmanager/init.lua
@@ -1,0 +1,23 @@
+local M = {}
+
+M.config = {
+  keymap = "<leader>cm",
+  window = {
+    size = 0.3,
+    position = "right",
+  },
+  command = "npx ccmanager",
+}
+
+function M.setup(opts)
+  M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+  
+  local terminal = require("ccmanager.terminal")
+  terminal.setup(M.config)
+  
+  vim.keymap.set("n", M.config.keymap, function()
+    terminal.toggle()
+  end, { desc = "Toggle CCManager" })
+end
+
+return M

--- a/lua/ccmanager/terminal.lua
+++ b/lua/ccmanager/terminal.lua
@@ -1,0 +1,41 @@
+local M = {}
+local terminal = nil
+
+function M.setup(config)
+  M.config = config
+end
+
+function M.toggle()
+  local ok, toggleterm = pcall(require, "toggleterm")
+  if not ok then
+    vim.notify("CCManager: toggleterm.nvim is required", vim.log.levels.ERROR)
+    return
+  end
+  
+  if not terminal then
+    local Terminal = require("toggleterm.terminal").Terminal
+    terminal = Terminal:new({
+      cmd = M.config.command,
+      dir = vim.fn.getcwd(),
+      direction = M.config.window.position == "right" and "vertical" or M.config.window.position,
+      size = function()
+        if M.config.window.position == "vertical" or M.config.window.position == "right" then
+          return vim.o.columns * M.config.window.size
+        else
+          return vim.o.lines * M.config.window.size
+        end
+      end,
+      close_on_exit = true,
+      hidden = false,
+      on_open = function(term)
+        vim.cmd("startinsert!")
+        vim.keymap.set("t", "<Esc>", [[<C-\><C-n>]], { buffer = term.bufnr })
+        vim.keymap.set("t", "<C-w>", [[<C-\><C-n><C-w>]], { buffer = term.bufnr })
+      end,
+    })
+  end
+  
+  terminal:toggle()
+end
+
+return M

--- a/plugin/ccmanager.lua
+++ b/plugin/ccmanager.lua
@@ -1,0 +1,9 @@
+if vim.fn.has("nvim-0.11.0") == 0 then
+  vim.api.nvim_err_writeln("CCManager requires at least nvim-0.11.0")
+  return
+end
+
+if vim.g.loaded_ccmanager == 1 then
+  return
+end
+vim.g.loaded_ccmanager = 1


### PR DESCRIPTION
  ## Summary
  - Neovim plugin for CCManager (Claude Code Session Manager)
  - Integrates CCManager TUI into Neovim using toggleterm.nvim
  - Provides easy access to manage multiple Claude Code sessions

  ## Features
  - Toggle CCManager with `<leader>cm` (configurable)
  - Vertical split window on the right side by default
  - Support for window size and position configuration
  - Terminal mode key mappings for easy navigation
  - Japanese documentation included

  ## Requirements
  - Neovim >= 0.11.0
  - toggleterm.nvim
  - Node.js (for npx ccmanager)