### PR TITLE
fix: 垂直分割時のウィンドウ幅が狭すぎる問題を修正

### DIFF
--- a/lua/ccmanager/terminal.lua
+++ b/lua/ccmanager/terminal.lua
@@ -18,10 +18,13 @@ function M.toggle()
       cmd = M.config.command,
       dir = vim.fn.getcwd(),
       direction = (M.config.window.position == "right" or M.config.window.position == "left") and "vertical" or M.config.window.position,
-      size = function()
-        if M.config.window.position == "right" or M.config.window.position == "left" then
-          return math.floor(vim.o.columns * M.config.window.size)
+      size = function(term)
+        if term.direction == "vertical" then
+          -- 垂直分割: 列数として計算し、最小幅を確保
+          local calculated_size = math.floor(vim.o.columns * M.config.window.size)
+          return math.max(calculated_size, 20)
         else
+          -- 水平分割: 行数として計算
           return math.floor(vim.o.lines * M.config.window.size)
         end
       end,


### PR DESCRIPTION
## Summary
- issue #4 で報告された垂直分割時のウィンドウ幅計算の問題を修正
- toggleterm.nvimのsize関数の実装を改善
- 最小幅20列を確保する安全策を追加

## 変更内容
1. `size`パラメータを関数として定義し、`term`パラメータを受け取るように変更
2. `term.direction`を使用して垂直/水平を適切に判定
3. `math.max`を使用して最小幅20列を確保

## テスト
- `<leader>cm`でCCManagerを起動し、垂直分割でウィンドウが適切な幅で表示されることを確認
- 異なるウィンドウサイズでも期待通りの30%幅で表示されることを確認

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)