### PR TITLE
fix: 垂直分割時のウィンドウ幅が正しく設定されない問題を修正 (#4)

### DIFF
--- a/lua/ccmanager/terminal.lua
+++ b/lua/ccmanager/terminal.lua
@@ -22,15 +22,23 @@ function M.toggle()
         if term.direction == "vertical" then
           -- 垂直分割: 列数として計算し、最小幅を確保
           local calculated_size = math.floor(vim.o.columns * M.config.window.size)
-          return math.max(calculated_size, 20)
+          -- デバッグ情報を追加（本番環境では削除）
+          -- vim.notify(string.format("CCManager: Calculated width: %d (columns: %d, size: %.2f)", calculated_size, vim.o.columns, M.config.window.size))
+          return math.max(calculated_size, 30)  -- 最小幅を30に増加
         else
           -- 水平分割: 行数として計算
           return math.floor(vim.o.lines * M.config.window.size)
         end
       end,
+      persist_size = false,  -- サイズの再計算を許可
       close_on_exit = true,
       hidden = false,
       on_open = function(term)
+        -- 垂直分割の場合、ウィンドウサイズを明示的に設定
+        if term.direction == "vertical" then
+          local expected_width = math.max(math.floor(vim.o.columns * M.config.window.size), 30)
+          vim.api.nvim_win_set_width(0, expected_width)
+        end
         vim.cmd("startinsert!")
         vim.keymap.set("t", "<Esc>", [[<C-\><C-n>]], { buffer = term.bufnr })
         vim.keymap.set("t", "<C-w>", [[<C-\><C-n><C-w>]], { buffer = term.bufnr })


### PR DESCRIPTION
## Summary
- 垂直分割時のウィンドウ幅計算を改善し、期待される30%の幅で表示されるように修正
- toggleterm.nvimのpersist_sizeパラメータを追加し、ウィンドウサイズの動的な再計算を許可
- on_openコールバックで明示的にウィンドウ幅を設定する処理を追加

## Changes
1. 最小幅を20から30に増加して、より実用的な表示を確保
2. `persist_size = false` を追加し、ウィンドウサイズの動的な再計算を許可
3. `on_open`コールバックで`vim.api.nvim_win_set_width()`を使用して、垂直分割時のウィンドウ幅を明示的に設定

## Test plan
- [ ] Neovim 0.11.0以上の環境でプラグインをインストール
- [ ] デフォルト設定（position = "right", size = 0.3）でCCManagerを起動
- [ ] ウィンドウが画面幅の30%で正しく表示されることを確認
- [ ] position = "left"でも同様に動作することを確認
- [ ] 画面サイズを変更してもウィンドウ幅が適切に調整されることを確認

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)