### PR TITLE
fix: ターミナルモードでエスケープキーが期待通りに動作しない問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ require("ccmanager").setup({
     position = "right",            -- Window position: "right", "left", "bottom", "top"
   },
   command = "npx ccmanager",       -- Command to run CCManager
+  terminal_keymaps = {
+    normal_mode = "<C-q>",         -- Keymap to exit terminal mode (default: <C-q>)
+    window_nav = "<C-w>",          -- Keymap for window navigation (default: <C-w>)
+  },
 })
 ```
 
@@ -58,8 +62,9 @@ Press `<leader>cm` (default) to toggle the CCManager terminal window.
 
 ### Key mappings in terminal mode / ターミナルモードでのキーマッピング
 
-- `<Esc>` - Exit terminal mode to normal mode / ターミナルモードからノーマルモードへ
+- `<C-q>` - Exit terminal mode to normal mode / ターミナルモードからノーマルモードへ
 - `<C-w>` - Window navigation from terminal mode / ターミナルモードからのウィンドウ操作
+- `<Esc>` - Passed through to CCManager for TUI operations / CCManagerのTUI操作に使用
 
 ## Credits
 

--- a/lua/ccmanager/init.lua
+++ b/lua/ccmanager/init.lua
@@ -7,6 +7,13 @@ M.config = {
     position = "right",
   },
   command = "npx ccmanager",
+  terminal_keymaps = {
+    -- ターミナルモードから通常モードへの切り替え
+    -- エスケープキーのマッピングを削除し、代わりに<C-q>を使用
+    normal_mode = "<C-q>",
+    -- ウィンドウ操作のキーマッピング
+    window_nav = "<C-w>",
+  },
 }
 
 function M.setup(opts)

--- a/lua/ccmanager/terminal.lua
+++ b/lua/ccmanager/terminal.lua
@@ -32,8 +32,14 @@ function M.toggle()
       hidden = false,
       on_open = function(term)
         vim.cmd("startinsert!")
-        vim.keymap.set("t", "<Esc>", [[<C-\><C-n>]], { buffer = term.bufnr })
-        vim.keymap.set("t", "<C-w>", [[<C-\><C-n><C-w>]], { buffer = term.bufnr })
+        -- エスケープキーはCCManagerのTUI操作に使用されるため、マッピングしない
+        -- 代わりに設定可能なキーで通常モードへ切り替え
+        if M.config.terminal_keymaps and M.config.terminal_keymaps.normal_mode then
+          vim.keymap.set("t", M.config.terminal_keymaps.normal_mode, [[<C-\><C-n>]], { buffer = term.bufnr, desc = "Exit terminal mode" })
+        end
+        if M.config.terminal_keymaps and M.config.terminal_keymaps.window_nav then
+          vim.keymap.set("t", M.config.terminal_keymaps.window_nav, [[<C-\><C-n><C-w>]], { buffer = term.bufnr, desc = "Window navigation" })
+        end
       end,
     })
   end


### PR DESCRIPTION
## Summary
- エスケープキーのマッピングを削除し、CCManagerのTUI操作で使用できるように修正
- 代わりに`<C-q>`を通常モードへの切り替えに使用
- ユーザーがカスタマイズ可能な`terminal_keymaps`設定を追加

## 修正内容
1. `lua/ccmanager/init.lua`: 新しい`terminal_keymaps`設定を追加
2. `lua/ccmanager/terminal.lua`: エスケープキーのマッピングを削除し、設定可能なキーバインドに変更
3. `README.md`: 新しいキーバインドについてのドキュメントを更新

## Test plan
- [x] CCManagerを起動し、エスケープキーがTUI操作に正しく渡されることを確認
- [x] `<C-q>`でターミナルモードから通常モードに切り替えられることを確認
- [x] カスタム設定でキーバインドが変更できることを確認

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)