### PR TITLE
feat: ユーザー設定のバリデーション機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,42 @@ Press `<leader>cm` (default) to toggle the CCManager terminal window.
 - `<C-w>` - Window navigation from terminal mode / ターミナルモードからのウィンドウ操作
 - `<Esc>` - Passed through to CCManager for TUI operations / CCManagerのTUI操作に使用
 
+### Commands / コマンド
+
+- `:CCManagerShowConfig` - Display current configuration / 現在の設定を表示
+- `:CCManagerValidateConfig` - Validate current configuration / 現在の設定を検証
+
+## Configuration Validation / 設定のバリデーション
+
+CCManager automatically validates your configuration to prevent errors:
+
+CCManagerは設定を自動的に検証してエラーを防ぎます：
+
+### Validated Settings / 検証される設定
+
+- **window.size**: Must be a number between 0 and 1 / 0から1の間の数値である必要があります
+- **window.position**: Must be one of: `right`, `left`, `float`, `bottom`, `top`, `vertical`, `horizontal`
+- **command**: Must be a non-empty string / 空でない文字列である必要があります
+- **keymap**: Must be a valid keymap string / 有効なキーマップ文字列である必要があります
+- **terminal_keymaps**: Must be a table with string values / 文字列値を持つテーブルである必要があります
+- **wsl_optimization**: Must contain boolean values / ブール値を含む必要があります
+
+### Example / 例
+
+```lua
+require("ccmanager").setup({
+  window = {
+    size = 2.0,  -- Invalid: will be set to 0.3 (default)
+    position = "center",  -- Invalid: will be set to "right" (default)
+  },
+  command = "",  -- Invalid: will be set to "npx ccmanager" (default)
+})
+```
+
+Invalid settings will be replaced with defaults and you'll see a warning message.
+
+無効な設定はデフォルト値に置き換えられ、警告メッセージが表示されます。
+
 ## Troubleshooting / トラブルシューティング
 
 ### WSL2 Paste Issues / WSL2でのペースト問題

--- a/lua/ccmanager/config.lua
+++ b/lua/ccmanager/config.lua
@@ -76,7 +76,8 @@ validators.keymap = function(value)
     return false, "keymap cannot be empty"
   end
   -- 基本的なキーマップパターンをチェック
-  if not value:match("^[<]?[%w%-]+[>]?") then
+  -- <leader>、<C-x>、\cm、<F5>などの一般的なパターンを許可
+  if not (value:match("^<.+>") or value:match("^\\%w+") or value:match("^[%w%-]+$")) then
     return false, "keymap appears to be invalid"
   end
   return true

--- a/lua/ccmanager/config.lua
+++ b/lua/ccmanager/config.lua
@@ -1,0 +1,225 @@
+local M = {}
+
+-- デフォルト設定
+M.defaults = {
+  keymap = "<leader>cm",
+  window = {
+    size = 0.3,
+    position = "right",
+  },
+  command = "npx ccmanager",
+  terminal_keymaps = {
+    normal_mode = "<C-q>",
+    window_nav = "<C-w>",
+    paste = "<C-S-v>",
+  },
+  wsl_optimization = {
+    enabled = true,
+    check_clipboard = true,
+    fix_paste = true,
+  },
+}
+
+-- バリデーションルール
+local validators = {}
+
+-- window.sizeのバリデーション
+validators.window_size = function(value)
+  if type(value) ~= "number" then
+    return false, "window.size must be a number"
+  end
+  if value < 0 or value > 1 then
+    return false, "window.size must be between 0 and 1"
+  end
+  return true
+end
+
+-- window.positionのバリデーション
+validators.window_position = function(value)
+  local valid_positions = {
+    right = true,
+    left = true,
+    float = true,
+    bottom = true,
+    top = true,
+    vertical = true,
+    horizontal = true,
+  }
+  if type(value) ~= "string" then
+    return false, "window.position must be a string"
+  end
+  if not valid_positions[value] then
+    local valid_list = vim.tbl_keys(valid_positions)
+    table.sort(valid_list)
+    return false, string.format("window.position must be one of: %s", table.concat(valid_list, ", "))
+  end
+  return true
+end
+
+-- commandのバリデーション
+validators.command = function(value)
+  if type(value) ~= "string" then
+    return false, "command must be a string"
+  end
+  if value == "" then
+    return false, "command cannot be empty"
+  end
+  return true
+end
+
+-- keymapのバリデーション
+validators.keymap = function(value)
+  if type(value) ~= "string" then
+    return false, "keymap must be a string"
+  end
+  if value == "" then
+    return false, "keymap cannot be empty"
+  end
+  -- 基本的なキーマップパターンをチェック
+  if not value:match("^[<]?[%w%-]+[>]?") then
+    return false, "keymap appears to be invalid"
+  end
+  return true
+end
+
+-- terminal_keymapsのバリデーション
+validators.terminal_keymaps = function(value)
+  if type(value) ~= "table" then
+    return false, "terminal_keymaps must be a table"
+  end
+  
+  -- 各キーマップをチェック
+  for key, keymap in pairs(value) do
+    if type(keymap) ~= "string" then
+      return false, string.format("terminal_keymaps.%s must be a string", key)
+    end
+  end
+  
+  return true
+end
+
+-- wsl_optimizationのバリデーション
+validators.wsl_optimization = function(value)
+  if type(value) ~= "table" then
+    return false, "wsl_optimization must be a table"
+  end
+  
+  -- 各設定をチェック
+  if value.enabled ~= nil and type(value.enabled) ~= "boolean" then
+    return false, "wsl_optimization.enabled must be a boolean"
+  end
+  if value.check_clipboard ~= nil and type(value.check_clipboard) ~= "boolean" then
+    return false, "wsl_optimization.check_clipboard must be a boolean"
+  end
+  if value.fix_paste ~= nil and type(value.fix_paste) ~= "boolean" then
+    return false, "wsl_optimization.fix_paste must be a boolean"
+  end
+  
+  return true
+end
+
+-- バリデーション実行
+local function validate_field(field_path, value, validator)
+  local ok, err = validator(value)
+  if not ok then
+    vim.notify(string.format("CCManager: Invalid config - %s", err), vim.log.levels.WARN)
+    return false
+  end
+  return true
+end
+
+-- 設定のバリデーションと正規化
+function M.validate(config)
+  config = config or {}
+  local validated = vim.deepcopy(config)
+  local has_errors = false
+  
+  -- window設定のバリデーション
+  if validated.window then
+    if validated.window.size ~= nil then
+      if not validate_field("window.size", validated.window.size, validators.window_size) then
+        validated.window.size = M.defaults.window.size
+        has_errors = true
+      end
+    end
+    
+    if validated.window.position ~= nil then
+      if not validate_field("window.position", validated.window.position, validators.window_position) then
+        validated.window.position = M.defaults.window.position
+        has_errors = true
+      end
+    end
+  end
+  
+  -- commandのバリデーション
+  if validated.command ~= nil then
+    if not validate_field("command", validated.command, validators.command) then
+      validated.command = M.defaults.command
+      has_errors = true
+    end
+  end
+  
+  -- keymapのバリデーション
+  if validated.keymap ~= nil then
+    if not validate_field("keymap", validated.keymap, validators.keymap) then
+      validated.keymap = M.defaults.keymap
+      has_errors = true
+    end
+  end
+  
+  -- terminal_keymapsのバリデーション
+  if validated.terminal_keymaps ~= nil then
+    if not validate_field("terminal_keymaps", validated.terminal_keymaps, validators.terminal_keymaps) then
+      validated.terminal_keymaps = M.defaults.terminal_keymaps
+      has_errors = true
+    end
+  end
+  
+  -- wsl_optimizationのバリデーション
+  if validated.wsl_optimization ~= nil then
+    if not validate_field("wsl_optimization", validated.wsl_optimization, validators.wsl_optimization) then
+      validated.wsl_optimization = M.defaults.wsl_optimization
+      has_errors = true
+    end
+  end
+  
+  if has_errors then
+    vim.notify("CCManager: Some invalid settings were replaced with defaults", vim.log.levels.INFO)
+  end
+  
+  return validated
+end
+
+-- デフォルト設定とマージ
+function M.merge_with_defaults(config)
+  local validated = M.validate(config)
+  return vim.tbl_deep_extend("force", M.defaults, validated)
+end
+
+-- 設定のサマリーを表示
+function M.show_config(config)
+  local lines = {
+    "CCManager Configuration:",
+    "========================",
+    string.format("Keymap: %s", config.keymap),
+    string.format("Command: %s", config.command),
+    "",
+    "Window:",
+    string.format("  Size: %.1f%%", config.window.size * 100),
+    string.format("  Position: %s", config.window.position),
+    "",
+    "Terminal Keymaps:",
+    string.format("  Normal mode: %s", config.terminal_keymaps.normal_mode or "not set"),
+    string.format("  Window nav: %s", config.terminal_keymaps.window_nav or "not set"),
+    string.format("  Paste: %s", config.terminal_keymaps.paste or "not set"),
+    "",
+    "WSL2 Optimization:",
+    string.format("  Enabled: %s", tostring(config.wsl_optimization.enabled)),
+    string.format("  Check clipboard: %s", tostring(config.wsl_optimization.check_clipboard)),
+    string.format("  Fix paste: %s", tostring(config.wsl_optimization.fix_paste)),
+  }
+  
+  vim.notify(table.concat(lines, "\n"), vim.log.levels.INFO)
+end
+
+return M

--- a/lua/ccmanager/init.lua
+++ b/lua/ccmanager/init.lua
@@ -1,38 +1,36 @@
 local M = {}
+local config_module = require("ccmanager.config")
 
-M.config = {
-  keymap = "<leader>cm",
-  window = {
-    size = 0.3,
-    position = "right",
-  },
-  command = "npx ccmanager",
-  terminal_keymaps = {
-    -- ターミナルモードから通常モードへの切り替え
-    -- エスケープキーのマッピングを削除し、代わりに<C-q>を使用
-    normal_mode = "<C-q>",
-    -- ウィンドウ操作のキーマッピング
-    window_nav = "<C-w>",
-    -- ペースト用のキーマッピング（WSL2環境で有用）
-    paste = "<C-S-v>",
-  },
-  -- WSL2環境での最適化
-  wsl_optimization = {
-    enabled = true,  -- WSL2環境での最適化を有効化
-    check_clipboard = true,  -- クリップボード設定をチェック
-    fix_paste = true,  -- ペースト問題の修正を適用
-  },
-}
+-- デフォルト設定はconfig.luaから取得
+M.config = config_module.defaults
 
 function M.setup(opts)
-  M.config = vim.tbl_deep_extend("force", M.config, opts or {})
+  -- 設定のバリデーションとマージ
+  M.config = config_module.merge_with_defaults(opts)
   
   local terminal = require("ccmanager.terminal")
   terminal.setup(M.config)
   
-  vim.keymap.set("n", M.config.keymap, function()
+  -- キーマップの設定
+  local ok = pcall(vim.keymap.set, "n", M.config.keymap, function()
     terminal.toggle()
   end, { desc = "Toggle CCManager" })
+  
+  if not ok then
+    vim.notify("CCManager: Failed to set keymap. Please check your keymap setting.", vim.log.levels.ERROR)
+  end
+  
+  -- コマンドの登録
+  vim.api.nvim_create_user_command("CCManagerShowConfig", function()
+    config_module.show_config(M.config)
+  end, { desc = "Show CCManager configuration" })
+  
+  vim.api.nvim_create_user_command("CCManagerValidateConfig", function()
+    local validation_result = config_module.validate(M.config)
+    if validation_result then
+      vim.notify("CCManager: Configuration is valid", vim.log.levels.INFO)
+    end
+  end, { desc = "Validate CCManager configuration" })
 end
 
 return M

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -1,0 +1,212 @@
+describe("ccmanager config", function()
+  local config
+  
+  before_each(function()
+    -- モジュールキャッシュをクリア
+    package.loaded["ccmanager.config"] = nil
+    config = require("ccmanager.config")
+  end)
+  
+  describe("validate", function()
+    it("should accept valid window.size", function()
+      local test_config = { window = { size = 0.5 } }
+      local result = config.validate(test_config)
+      assert.equals(0.5, result.window.size)
+    end)
+    
+    it("should reject invalid window.size (not a number)", function()
+      local notify_called = false
+      vim.notify = function(msg, level)
+        notify_called = true
+        assert.truthy(string.find(msg, "window.size must be a number"))
+      end
+      
+      local test_config = { window = { size = "invalid" } }
+      local result = config.validate(test_config)
+      assert.is_true(notify_called)
+      assert.equals(config.defaults.window.size, result.window.size)
+    end)
+    
+    it("should reject invalid window.size (out of range)", function()
+      local notify_called = false
+      vim.notify = function(msg, level)
+        notify_called = true
+        assert.truthy(string.find(msg, "window.size must be between 0 and 1"))
+      end
+      
+      local test_config = { window = { size = 1.5 } }
+      local result = config.validate(test_config)
+      assert.is_true(notify_called)
+      assert.equals(config.defaults.window.size, result.window.size)
+    end)
+    
+    it("should accept valid window.position", function()
+      local positions = {"right", "left", "float", "bottom", "top", "vertical", "horizontal"}
+      for _, pos in ipairs(positions) do
+        local test_config = { window = { position = pos } }
+        local result = config.validate(test_config)
+        assert.equals(pos, result.window.position)
+      end
+    end)
+    
+    it("should reject invalid window.position", function()
+      local notify_called = false
+      vim.notify = function(msg, level)
+        notify_called = true
+        assert.truthy(string.find(msg, "window.position must be one of"))
+      end
+      
+      local test_config = { window = { position = "invalid" } }
+      local result = config.validate(test_config)
+      assert.is_true(notify_called)
+      assert.equals(config.defaults.window.position, result.window.position)
+    end)
+    
+    it("should accept valid command", function()
+      local test_config = { command = "npx ccmanager --debug" }
+      local result = config.validate(test_config)
+      assert.equals("npx ccmanager --debug", result.command)
+    end)
+    
+    it("should reject empty command", function()
+      local notify_called = false
+      vim.notify = function(msg, level)
+        notify_called = true
+        assert.truthy(string.find(msg, "command cannot be empty"))
+      end
+      
+      local test_config = { command = "" }
+      local result = config.validate(test_config)
+      assert.is_true(notify_called)
+      assert.equals(config.defaults.command, result.command)
+    end)
+    
+    it("should accept valid keymap", function()
+      local keymaps = {"<leader>cm", "<C-c>", "\\cm", "<F5>"}
+      for _, km in ipairs(keymaps) do
+        local test_config = { keymap = km }
+        local result = config.validate(test_config)
+        assert.equals(km, result.keymap)
+      end
+    end)
+    
+    it("should reject invalid keymap", function()
+      local notify_called = false
+      vim.notify = function(msg, level)
+        notify_called = true
+      end
+      
+      local test_config = { keymap = "" }
+      local result = config.validate(test_config)
+      assert.is_true(notify_called)
+      assert.equals(config.defaults.keymap, result.keymap)
+    end)
+    
+    it("should validate terminal_keymaps", function()
+      local test_config = {
+        terminal_keymaps = {
+          normal_mode = "<C-\\>",
+          window_nav = "<C-w>",
+          paste = "<C-v>",
+        }
+      }
+      local result = config.validate(test_config)
+      assert.same(test_config.terminal_keymaps, result.terminal_keymaps)
+    end)
+    
+    it("should reject invalid terminal_keymaps", function()
+      local notify_called = false
+      vim.notify = function(msg, level)
+        notify_called = true
+        assert.truthy(string.find(msg, "terminal_keymaps"))
+      end
+      
+      local test_config = { terminal_keymaps = "invalid" }
+      local result = config.validate(test_config)
+      assert.is_true(notify_called)
+      assert.same(config.defaults.terminal_keymaps, result.terminal_keymaps)
+    end)
+    
+    it("should validate wsl_optimization settings", function()
+      local test_config = {
+        wsl_optimization = {
+          enabled = false,
+          check_clipboard = false,
+          fix_paste = true,
+        }
+      }
+      local result = config.validate(test_config)
+      assert.same(test_config.wsl_optimization, result.wsl_optimization)
+    end)
+    
+    it("should reject invalid wsl_optimization.enabled", function()
+      local notify_called = false
+      vim.notify = function(msg, level)
+        notify_called = true
+        assert.truthy(string.find(msg, "wsl_optimization.enabled must be a boolean"))
+      end
+      
+      local test_config = {
+        wsl_optimization = {
+          enabled = "yes",
+        }
+      }
+      local result = config.validate(test_config)
+      assert.is_true(notify_called)
+    end)
+  end)
+  
+  describe("merge_with_defaults", function()
+    it("should merge partial config with defaults", function()
+      local test_config = {
+        keymap = "<leader>x",
+        window = {
+          size = 0.4,
+        }
+      }
+      
+      local result = config.merge_with_defaults(test_config)
+      
+      -- カスタム値が保持される
+      assert.equals("<leader>x", result.keymap)
+      assert.equals(0.4, result.window.size)
+      
+      -- デフォルト値が使用される
+      assert.equals(config.defaults.window.position, result.window.position)
+      assert.equals(config.defaults.command, result.command)
+      assert.same(config.defaults.terminal_keymaps, result.terminal_keymaps)
+      assert.same(config.defaults.wsl_optimization, result.wsl_optimization)
+    end)
+    
+    it("should handle nil config", function()
+      local result = config.merge_with_defaults(nil)
+      assert.same(config.defaults, result)
+    end)
+    
+    it("should handle empty config", function()
+      local result = config.merge_with_defaults({})
+      assert.same(config.defaults, result)
+    end)
+  end)
+  
+  describe("show_config", function()
+    it("should display configuration summary", function()
+      local notify_called = false
+      local notify_msg = nil
+      
+      vim.notify = function(msg, level)
+        notify_called = true
+        notify_msg = msg
+      end
+      
+      config.show_config(config.defaults)
+      
+      assert.is_true(notify_called)
+      assert.truthy(string.find(notify_msg, "CCManager Configuration"))
+      assert.truthy(string.find(notify_msg, "Keymap:"))
+      assert.truthy(string.find(notify_msg, "Window:"))
+      assert.truthy(string.find(notify_msg, "Terminal Keymaps:"))
+      assert.truthy(string.find(notify_msg, "WSL2 Optimization:"))
+    end)
+  end)
+end)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -15,28 +15,42 @@ describe("ccmanager config", function()
     end)
     
     it("should reject invalid window.size (not a number)", function()
-      local notify_called = false
+      local notify_messages = {}
       vim.notify = function(msg, level)
-        notify_called = true
-        assert.truthy(string.find(msg, "window.size must be a number"))
+        table.insert(notify_messages, msg)
       end
       
       local test_config = { window = { size = "invalid" } }
       local result = config.validate(test_config)
-      assert.is_true(notify_called)
+      assert.is_true(#notify_messages > 0)
+      local found = false
+      for _, msg in ipairs(notify_messages) do
+        if string.find(msg, "window.size must be a number") then
+          found = true
+          break
+        end
+      end
+      assert.is_true(found)
       assert.equals(config.defaults.window.size, result.window.size)
     end)
     
     it("should reject invalid window.size (out of range)", function()
-      local notify_called = false
+      local notify_messages = {}
       vim.notify = function(msg, level)
-        notify_called = true
-        assert.truthy(string.find(msg, "window.size must be between 0 and 1"))
+        table.insert(notify_messages, msg)
       end
       
       local test_config = { window = { size = 1.5 } }
       local result = config.validate(test_config)
-      assert.is_true(notify_called)
+      assert.is_true(#notify_messages > 0)
+      local found = false
+      for _, msg in ipairs(notify_messages) do
+        if string.find(msg, "window.size must be between 0 and 1") then
+          found = true
+          break
+        end
+      end
+      assert.is_true(found)
       assert.equals(config.defaults.window.size, result.window.size)
     end)
     
@@ -50,15 +64,22 @@ describe("ccmanager config", function()
     end)
     
     it("should reject invalid window.position", function()
-      local notify_called = false
+      local notify_messages = {}
       vim.notify = function(msg, level)
-        notify_called = true
-        assert.truthy(string.find(msg, "window.position must be one of"))
+        table.insert(notify_messages, msg)
       end
       
       local test_config = { window = { position = "invalid" } }
       local result = config.validate(test_config)
-      assert.is_true(notify_called)
+      assert.is_true(#notify_messages > 0)
+      local found = false
+      for _, msg in ipairs(notify_messages) do
+        if string.find(msg, "window.position must be one of") then
+          found = true
+          break
+        end
+      end
+      assert.is_true(found)
       assert.equals(config.defaults.window.position, result.window.position)
     end)
     
@@ -69,15 +90,22 @@ describe("ccmanager config", function()
     end)
     
     it("should reject empty command", function()
-      local notify_called = false
+      local notify_messages = {}
       vim.notify = function(msg, level)
-        notify_called = true
-        assert.truthy(string.find(msg, "command cannot be empty"))
+        table.insert(notify_messages, msg)
       end
       
       local test_config = { command = "" }
       local result = config.validate(test_config)
-      assert.is_true(notify_called)
+      assert.is_true(#notify_messages > 0)
+      local found = false
+      for _, msg in ipairs(notify_messages) do
+        if string.find(msg, "command cannot be empty") then
+          found = true
+          break
+        end
+      end
+      assert.is_true(found)
       assert.equals(config.defaults.command, result.command)
     end)
     
@@ -115,15 +143,22 @@ describe("ccmanager config", function()
     end)
     
     it("should reject invalid terminal_keymaps", function()
-      local notify_called = false
+      local notify_messages = {}
       vim.notify = function(msg, level)
-        notify_called = true
-        assert.truthy(string.find(msg, "terminal_keymaps"))
+        table.insert(notify_messages, msg)
       end
       
       local test_config = { terminal_keymaps = "invalid" }
       local result = config.validate(test_config)
-      assert.is_true(notify_called)
+      assert.is_true(#notify_messages > 0)
+      local found = false
+      for _, msg in ipairs(notify_messages) do
+        if string.find(msg, "terminal_keymaps") then
+          found = true
+          break
+        end
+      end
+      assert.is_true(found)
       assert.same(config.defaults.terminal_keymaps, result.terminal_keymaps)
     end)
     
@@ -140,10 +175,9 @@ describe("ccmanager config", function()
     end)
     
     it("should reject invalid wsl_optimization.enabled", function()
-      local notify_called = false
+      local notify_messages = {}
       vim.notify = function(msg, level)
-        notify_called = true
-        assert.truthy(string.find(msg, "wsl_optimization.enabled must be a boolean"))
+        table.insert(notify_messages, msg)
       end
       
       local test_config = {
@@ -152,7 +186,15 @@ describe("ccmanager config", function()
         }
       }
       local result = config.validate(test_config)
-      assert.is_true(notify_called)
+      assert.is_true(#notify_messages > 0)
+      local found = false
+      for _, msg in ipairs(notify_messages) do
+        if string.find(msg, "wsl_optimization.enabled must be a boolean") then
+          found = true
+          break
+        end
+      end
+      assert.is_true(found)
     end)
   end)
   


### PR DESCRIPTION
## Summary
- ユーザー設定のバリデーション機能を実装
- 無効な設定を自動的にデフォルト値に置き換え
- 設定の表示・検証コマンドを追加

## Changes
### 🆕 New Features
- **config.luaモジュール**: 設定のバリデーションとデフォルト値管理
  - 各設定項目の型と値の検証
  - 無効な設定の自動修正
  - 設定のマージ機能

- **バリデーション対象**:
  - `window.size`: 0〜1の範囲内の数値
  - `window.position`: 有効な位置文字列
  - `command`: 空でない文字列
  - `keymap`: 有効なキーマップ形式
  - `terminal_keymaps`: テーブル型と文字列値
  - `wsl_optimization`: ブール値

- **新しいコマンド**:
  - `:CCManagerShowConfig` - 現在の設定を表示
  - `:CCManagerValidateConfig` - 設定の検証

### 🔧 Improvements
- setup()関数でバリデーションを自動実行
- 無効な設定に対する分かりやすい警告メッセージ
- デフォルト値への自動フォールバック

### 📚 Documentation
- READMEに設定バリデーションの説明を追加
- 各設定項目の制約を明記
- 無効な設定の例を提示

### ✅ Tests
- config.luaモジュールの包括的なテストを追加
- 既存テストを更新（バリデーション機能に対応）

## Related Issue
Closes #10

## Test Plan
- [x] 全てのテストが成功することを確認
- [x] 無効な設定が正しくデフォルト値に置き換えられることを確認
- [x] 警告メッセージが適切に表示されることを確認
- [x] 新しいコマンドが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)